### PR TITLE
Adding the Adobe Authentic Trust Document OID

### DIFF
--- a/.github/workflows/sort.yaml
+++ b/.github/workflows/sort.yaml
@@ -1,0 +1,16 @@
+name: Checking Sorting of Data
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  Sort:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - run: LC_ALL='C' sort -c -g x509/certificate_policies.csv
+      - run: LC_ALL='C' sort -c -g x509/extended_key_usage.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-script:
-  - LC_ALL='C' sort -c -g x509/certificate_policies.csv
-  - LC_ALL='C' sort -c -g x509/extended_key_usage.csv

--- a/x509/extended_key_usage.csv
+++ b/x509/extended_key_usage.csv
@@ -1,4 +1,5 @@
 oid,owner,short_name,description
+1.2.840.113583.1.1.5,Adobe,adobe-authentic-document-trust,
 1.2.840.113635.100.4.1,Apple,apple-code-signing,
 1.2.840.113635.100.4.1.1,Apple,apple-code-signing-development,
 1.2.840.113635.100.4.1.2,Apple,apple-software-update-signing,


### PR DESCRIPTION
I did decide to try to port the Travis file to GHA because Travis was refusing to trigger even at after 24 hours, so I reckon that hookup has gone stale.